### PR TITLE
Fix Travis CI / Sidekiq 4.0 test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ rvm:
   - jruby
   - jruby-head
   - rbx-2
+env:
+  - SIDEKIQ='~> 3.5'
+  - SIDEKIQ='~> 4.0'
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sidekiq-dejavu.gemspec
 gemspec
 
+gem "sidekiq", ENV['SIDEKIQ'] if ENV['SIDEKIQ']
 gem "minitest"
-gem "pry"
+gem "minitest-utils"
+gem "redis-namespace"
+gem "pry" unless ENV['CI']

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,10 +1,15 @@
+# disable minitest/parallel threads
+ENV["N"] = "0"
+
+require "bundler/setup"
+
 require "sidekiq"
 require "sidekiq/api"
 require "sidekiq/testing"
 
 require "minitest/autorun"
 require "yaml"
-require "pry"
+require "pry" unless ENV['CI']
 
 require "sidekiq/dejavu"
 


### PR DESCRIPTION
- Add missing redis-namespace gem for 4.0
- Add minitest-utils for nicer test output
- Disable pry in CI environments
- Test against sidekiq 3.x and 4.x
